### PR TITLE
Fix Vercel routing configuration

### DIFF
--- a/Frontend/vercel.json
+++ b/Frontend/vercel.json
@@ -1,8 +1,5 @@
 {
-  "routes": [
-    { "handle": "filesystem" }
-  ],
   "rewrites": [
     { "source": "/(.*)", "destination": "/" }
   ]
-}
+} 


### PR DESCRIPTION
- Remove conflicting 'routes' property from vercel.json
- Keep 'rewrites' for SPA routing to resolve mixed routing properties error